### PR TITLE
feat: Add story for externally controlled ThreePanelLayout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a24z/panels",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a24z/panels",
-      "version": "1.0.4",
+      "version": "1.0.6",
       "license": "MIT",
       "devDependencies": {
         "@storybook/addon-essentials": "^7.6.0",

--- a/src/components/ThreePanelLayout.stories.tsx
+++ b/src/components/ThreePanelLayout.stories.tsx
@@ -202,3 +202,33 @@ export const WithCallbacks: Story = {
     onPanelResize: (sizes) => console.log('Panel sizes:', sizes),
   },
 };
+
+export const ControlledByExternalButtons: Story = {
+  render: () => {
+    const [leftCollapsed, setLeftCollapsed] = React.useState(false);
+    const [rightCollapsed, setRightCollapsed] = React.useState(false);
+
+    return (
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ padding: '10px', borderBottom: '1px solid #ccc', background: '#f7f7f7' }}>
+          <h4>External Controls</h4>
+          <button onClick={() => setLeftCollapsed(!leftCollapsed)} style={{ marginRight: '10px' }}>
+            Toggle Left Panel
+          </button>
+          <button onClick={() => setRightCollapsed(!rightCollapsed)}>
+            Toggle Right Panel
+          </button>
+        </div>
+        <div style={{ flex: 1 }}>
+          <ThreePanelLayout
+            leftPanel={<LeftContent />}
+            middlePanel={<MiddleContent />}
+            rightPanel={<RightContent />}
+            collapsed={{ left: leftCollapsed, right: rightCollapsed }}
+            showCollapseButtons={true}
+          />
+        </div>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
Adds a new Storybook story named "ControlledByExternalButtons" to demonstrate how the ThreePanelLayout can be controlled by buttons outside the component itself.

This story uses React state to toggle the 'collapsed' prop for the left and right panels, providing a clear example of external state management for the component.