### PR TITLE
Ensure panel collapse state updates flush before animation

### DIFF
--- a/src/components/ThreePanelLayout.tsx
+++ b/src/components/ThreePanelLayout.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useState, useRef, useEffect, useCallback } from 'react';
+import { flushSync } from 'react-dom';
 import {
   Panel,
   PanelGroup,
@@ -231,8 +232,10 @@ export const ThreePanelLayout: React.FC<ThreePanelLayoutProps> = ({
   const handleLeftCollapse = useCallback(() => {
     if (leftAnimating || isDragging || !collapsiblePanels.left) return;
 
-    setLeftAnimating(true);
-    setLeftCollapsed(true);
+    flushSync(() => {
+      setLeftAnimating(true);
+      setLeftCollapsed(true);
+    });
     if (onLeftCollapseStart) onLeftCollapseStart();
 
     animatePanel(
@@ -269,8 +272,10 @@ export const ThreePanelLayout: React.FC<ThreePanelLayoutProps> = ({
   const handleLeftExpand = useCallback(() => {
     if (leftAnimating || isDragging || !collapsiblePanels.left) return;
 
-    setLeftAnimating(true);
-    setLeftCollapsed(false);
+    flushSync(() => {
+      setLeftAnimating(true);
+      setLeftCollapsed(false);
+    });
     if (onLeftExpandStart) onLeftExpandStart();
 
     animatePanel(
@@ -308,8 +313,10 @@ export const ThreePanelLayout: React.FC<ThreePanelLayoutProps> = ({
   const handleRightCollapse = useCallback(() => {
     if (rightAnimating || isDragging || !collapsiblePanels.right) return;
 
-    setRightAnimating(true);
-    setRightCollapsed(true);
+    flushSync(() => {
+      setRightAnimating(true);
+      setRightCollapsed(true);
+    });
     if (onRightCollapseStart) onRightCollapseStart();
 
     animatePanel(
@@ -346,8 +353,10 @@ export const ThreePanelLayout: React.FC<ThreePanelLayoutProps> = ({
   const handleRightExpand = useCallback(() => {
     if (rightAnimating || isDragging || !collapsiblePanels.right) return;
 
-    setRightAnimating(true);
-    setRightCollapsed(false);
+    flushSync(() => {
+      setRightAnimating(true);
+      setRightCollapsed(false);
+    });
     if (onRightExpandStart) onRightExpandStart();
 
     animatePanel(


### PR DESCRIPTION
## Summary
- import `flushSync` so panel state toggles re-render before animations begin
- wrap left and right collapse/expand handlers in `flushSync` while preserving animation sequencing

## Testing
- npm run build-storybook

------
https://chatgpt.com/codex/tasks/task_e_68dd0f95f4448321a02e3cf39a18784a